### PR TITLE
Allow use of "java_home" env var to specify the java runtime if configured

### DIFF
--- a/src/J2NET/Utilities/PathUtility.cs
+++ b/src/J2NET/Utilities/PathUtility.cs
@@ -8,6 +8,13 @@ namespace J2NET.Utilities
     {
         public static string GetRuntimePath()
         {
+            string javaHome = Environment.GetEnvironmentVariable("java_home");
+
+            if (javaHome != null)
+            {
+                return Path.Combine(javaHome, "bin", "java");
+            }
+
             var directory = Path.GetDirectoryName(typeof(PathUtility).Assembly.Location) ?? throw new DirectoryNotFoundException();
             var runtimeIdentifier = GetRuntimeIdentifier();
             return Path.Combine(directory, "runtimes", runtimeIdentifier, "openjre", "bin", "java");


### PR DESCRIPTION
Minor change to allow use of "java_home" environment variable if available rather than the embedded jre.