### PR TITLE
[QD-2080] Change OSArchitecture to ProcessArchitecture in PathUtility.GetRuntimeIdentifier method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Paste the following XML into your Project(*.csproj / .vbproj / .fsproj*) file.
 
 ```xml
 <PropertyGroup>
-    <RuntimeVersion>1.3.0</RuntimeVersion>
+    <RuntimeVersion>1.3.1</RuntimeVersion>
     <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">OSX</OSPlatform>
     <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">Linux</OSPlatform>
     <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">Windows</OSPlatform>
-    <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
+    <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</OSArchitecture>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/J2NET.Sample/J2NET.Sample.csproj
+++ b/src/J2NET.Sample/J2NET.Sample.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <RuntimeVersion>1.3.0</RuntimeVersion>
+        <RuntimeVersion>1.3.1</RuntimeVersion>
         <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">OSX</OSPlatform>
         <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">Linux</OSPlatform>
         <OSPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">Windows</OSPlatform>
-        <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
+        <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</OSArchitecture>
     </PropertyGroup>
 
     <ItemGroup Label="Development" Condition=" '$(RID)' == '' And '$(Packaging)' == '' ">

--- a/src/J2NET/Utilities/PathUtility.cs
+++ b/src/J2NET/Utilities/PathUtility.cs
@@ -15,7 +15,7 @@ namespace J2NET.Utilities
 
         public static string GetRuntimeIdentifier()
         {
-            var arch = RuntimeInformation.OSArchitecture;
+            var arch = RuntimeInformation.ProcessArchitecture;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {


### PR DESCRIPTION
This commit changes `OSArchitecture` to `ProcessArchitecture` in the `PathUtility.GetRuntimeIdentifier` method, as the runtime environment installed on the OS may differ from the OS's architecture.